### PR TITLE
Pass the $idList to buildFilterRulesForUsedOnly()

### DIFF
--- a/src/MetaModels/Attribute/Select/MetaModelSelect.php
+++ b/src/MetaModels/Attribute/Select/MetaModelSelect.php
@@ -11,6 +11,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Stefan heimes <stefan_heimes@hotmail.com>
  * @author     Martin Treml <github@r2pi.net>
+ * @author     David Maack <david.maack@arcor.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource

--- a/src/MetaModels/Attribute/Select/MetaModelSelect.php
+++ b/src/MetaModels/Attribute/Select/MetaModelSelect.php
@@ -369,7 +369,7 @@ class MetaModelSelect extends AbstractSelect
 
         // Add some more filter rules.
         if ($usedOnly) {
-            $this->buildFilterRulesForUsedOnly($filter);
+            $this->buildFilterRulesForUsedOnly($filter, $idList ? $idList : array());
 
         } elseif ($idList && is_array($idList)) {
             $filter->addFilterRule(new StaticIdList($idList));

--- a/src/MetaModels/Attribute/Select/MetaModelSelect.php
+++ b/src/MetaModels/Attribute/Select/MetaModelSelect.php
@@ -370,7 +370,7 @@ class MetaModelSelect extends AbstractSelect
 
         // Add some more filter rules.
         if ($usedOnly) {
-            $this->buildFilterRulesForUsedOnly($filter, $idList ? $idList : array());
+            $this->buildFilterRulesForUsedOnly($filter, $idList ?: array());
 
         } elseif ($idList && is_array($idList)) {
             $filter->addFilterRule(new StaticIdList($idList));


### PR DESCRIPTION
Pass the $idList to buildFilterRulesForUsedOnly() so the given id list will not be ignored when the used-only flag is set for the filter.